### PR TITLE
fix(map zoom): fix bug where map automatically zoomed out when zoomining in

### DIFF
--- a/airsen-frontend/src/app/features/map/map.component.html
+++ b/airsen-frontend/src/app/features/map/map.component.html
@@ -24,7 +24,7 @@
         </mat-card>
       </div>
 
-      <app-leaflet-map *ngIf="!(isLoading$ | async) && !(error$ | async)" [communes]="communes"
+      <app-leaflet-map *ngIf="!(error$ | async)" [communes]="communes"
         [selectedCommune]="selectedCommune" (communeClicked)="onCommuneClicked($event)"
         (zoomChanged)="onMapZoomChanged($event)"></app-leaflet-map>
 


### PR DESCRIPTION
The bug was caused by the isLoading$ observable in map.component.ts. Everytime it was loading new communes, it was also re-rendering the leaflet-map component, causing it to re-run it's ngAfterViewInit method and setting the zoom level back to it's original value. I simply removed the !isLoading$ condition in the ngIf of the leaflet-map component in the map.component.html and now everything works fine.